### PR TITLE
Fix GitHub Pages deployment while keeping Beautiful Jekyll theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source "https://rubygems.org"
 # Happy Jekylling!
 # gem "jekyll", "~> 4.3.1"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "beautiful-jekyll-theme"
+# gem "beautiful-jekyll-theme"  # Using remote theme instead for GitHub Pages compatibility
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    beautiful-jekyll-theme (6.0.1)
-      jekyll (>= 3.9.3)
-      jekyll-paginate (~> 1.1)
-      jekyll-sitemap (~> 1.4)
-      kramdown (~> 2.3.2)
-      kramdown-parser-gfm (~> 1.1)
-      webrick (~> 1.8)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -264,7 +257,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  beautiful-jekyll-theme
   github-pages
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)

--- a/_config.yml
+++ b/_config.yml
@@ -29,9 +29,10 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  paulin
 
 # Build settings
-theme: beautiful-jekyll-theme
+remote_theme: daattali/beautiful-jekyll
 plugins:
   - jekyll-feed
+  - jekyll-remote-theme
 
 background_image_url: /assets/images/background2.jpeg
 porthole_background_image_url: /assets/images/background2.jpeg


### PR DESCRIPTION
- Switched from beautiful-jekyll-theme gem to remote_theme approach
- Added jekyll-remote-theme plugin for GitHub Pages compatibility
- Kept all Beautiful Jekyll theme settings and customizations
- This allows GitHub Pages to use the theme while maintaining local functionality
- Remote theme: daattali/beautiful-jekyll